### PR TITLE
Switch to using ITypes for discovery by default

### DIFF
--- a/Source/DefaultMongoDBArtifacts.cs
+++ b/Source/DefaultMongoDBArtifacts.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Aksio Insurtech. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Aksio.Reflection;
 using Aksio.Types;
 
 namespace Aksio.MongoDB;
@@ -20,10 +19,10 @@ public class DefaultMongoDBArtifacts : IMongoDBArtifacts
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultMongoDBArtifacts"/> class.
     /// </summary>
-    /// <param name="assemblies"><see cref="ICanProvideAssembliesForDiscovery"/> for discovering types.</param>
-    public DefaultMongoDBArtifacts(ICanProvideAssembliesForDiscovery assemblies)
+    /// <param name="types"><see cref="ITypes"/> for discovering types.</param>
+    public DefaultMongoDBArtifacts(ITypes types)
     {
-        ClassMaps = assemblies.DefinedTypes.Where(_ => _.HasInterface(typeof(IBsonClassMapFor<>))).ToArray();
-        ConventionPackFilters = assemblies.DefinedTypes.Where(_ => _.HasInterface(typeof(ICanFilterMongoDBConventionPacksForType))).ToArray();
+        ClassMaps = types.FindMultiple(typeof(IBsonClassMapFor<>));
+        ConventionPackFilters = types.FindMultiple(typeof(ICanFilterMongoDBConventionPacksForType));
     }
 }

--- a/Source/MongoDBDefaults.cs
+++ b/Source/MongoDBDefaults.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text.Json;
 using Aksio.Json;
 using Aksio.Serialization;
-using Aksio.Types;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Conventions;
@@ -37,7 +36,7 @@ public static class MongoDBDefaults
             }
             _initialized = true;
 
-            mongoDBArtifacts ??= new DefaultMongoDBArtifacts(ProjectReferencedAssemblies.Instance);
+            mongoDBArtifacts ??= new DefaultMongoDBArtifacts(Types.Types.Instance);
             derivedTypes ??= DerivedTypes.Instance;
 
             var conventionPackFilters = mongoDBArtifacts


### PR DESCRIPTION
### Fixed

- Switching to use the `ITypes` default instance for the `DefaultMongoDBArtifacts` instead of just the project referenced assemblies. This way we are guaranteed all types we want.
