### PR TITLE
Fixing classmap hookup

### DIFF
--- a/Source/MongoDBDefaults.cs
+++ b/Source/MongoDBDefaults.cs
@@ -93,7 +93,7 @@ public static class MongoDBDefaults
                 return false;
             });
 
-            var method = typeof(MongoDBDefaults).GetMethod(nameof(Register), BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var method = typeof(MongoDBDefaults).GetMethod(nameof(Register), BindingFlags.Static | BindingFlags.NonPublic)!;
             foreach (var type in typeInterfaces)
             {
                 var genericMethod = method.MakeGenericMethod(type.GenericTypeArguments[0]);


### PR DESCRIPTION
### Fixed

- Fixing the hookup of class maps. After refactoring the calling of the generic `Register` method is now static and not an instance method.
