### PR TITLE
Fix/from-cratis

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
 	<ItemGroup>
 		<PackageVersion Include="Aksio.Defaults" Version="1.6.10" />
 		<PackageVersion Include="Aksio.Defaults.Specs" Version="1.6.10" />
-		<PackageVersion Include="Aksio.Fundamentals" Version="1.3.3" />
+		<PackageVersion Include="Aksio.Fundamentals" Version="1.3.4" />
         <PackageVersion Include="MongoDB.Driver" Version="2.17.1" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
 

--- a/Source/MongoDBClientFactory.cs
+++ b/Source/MongoDBClientFactory.cs
@@ -47,9 +47,15 @@ public class MongoDBClientFactory : IMongoDBClientFactory
         if (_logger.IsEnabled(LogLevel.Trace))
         {
             builder
-                .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson()))
-                .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message))
-                .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
+                .Subscribe<CommandStartedEvent>(CommandStarted)
+                .Subscribe<CommandFailedEvent>(CommandFailed)
+                .Subscribe<CommandSucceededEvent>(CommandSucceeded);
         }
     }
+
+    void CommandStarted(CommandStartedEvent command) => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson());
+
+    void CommandFailed(CommandFailedEvent command) => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message);
+
+    void CommandSucceeded(CommandSucceededEvent command) => _logger.CommandSucceeded(command.RequestId, command.CommandName);
 }

--- a/Source/MongoDBClientFactory.cs
+++ b/Source/MongoDBClientFactory.cs
@@ -6,6 +6,7 @@ using Aksio.Execution;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Configuration;
 using MongoDB.Driver.Core.Events;
 
 namespace Aksio.MongoDB;
@@ -36,18 +37,19 @@ public class MongoDBClientFactory : IMongoDBClientFactory
 
     IMongoClient CreateImplementation(MongoClientSettings settings)
     {
-        settings.ClusterConfigurator = builder =>
-        {
-            if (_logger.IsEnabled(LogLevel.Trace))
-            {
-                builder
-                    .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson()))
-                    .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message))
-                    .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
-            }
-        };
-
+        settings.ClusterConfigurator = ClusterConfigurator;
         _logger.CreateClient(settings.Server.ToString());
         return new MongoClient(settings);
+    }
+
+    void ClusterConfigurator(ClusterBuilder builder)
+    {
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            builder
+                .Subscribe<CommandStartedEvent>(command => _logger.CommandStarted(command.RequestId, command.CommandName, command.Command.ToJson()))
+                .Subscribe<CommandFailedEvent>(command => _logger.CommandFailed(command.RequestId, command.CommandName, command.Failure.Message))
+                .Subscribe<CommandSucceededEvent>(command => _logger.CommandSucceeded(command.RequestId, command.CommandName));
+        }
     }
 }


### PR DESCRIPTION
### Fixed

- Removing memory leakage from logging by formalizing the `Action<>` as private methods and also not enable logging unless `Trace` log level is set.
