### PR TITLE
Supporting object types that are in reality Guids with correct representation

### DIFF
--- a/Source/MongoDBDefaults.cs
+++ b/Source/MongoDBDefaults.cs
@@ -64,6 +64,12 @@ public static class MongoDBDefaults
             BsonSerializer
                 .RegisterSerializer(new GuidSerializer(GuidRepresentation.Standard));
 
+            // When you have types with properties defined as object but could hold a Guid, the GuidRepresentation gets by default set to Unspecified.
+            // By adding an object serializer for object configured explicitly with the Standard representation it should get serialized correctly and not throw an exception.
+            // As described here: https://jira.mongodb.org/browse/CSHARP-3780
+            BsonSerializer
+                .RegisterSerializer(new ObjectSerializer(BsonSerializer.LookupDiscriminatorConvention(typeof(object)), GuidRepresentation.Standard));
+
             foreach (var derivedType in derivedTypes.TypesWithDerivatives)
             {
                 BsonSerializer.RegisterDiscriminatorConvention(derivedType, new DerivedTypeDiscriminatorConvention(derivedTypes));


### PR DESCRIPTION
### Fixed

- When serializing types that has properties represented as object and the content is a `Guid`, by default it would throw an exception "GuidSerializer cannot serialize a Guid when GuidRepresentation is Unspecified.". This release adds an object serializer with the same Guid representation as other places.
