### PR TITLE
Fixing casting from ulong to long and back for concept types

### DIFF
--- a/Source/ConceptSerializer.cs
+++ b/Source/ConceptSerializer.cs
@@ -106,9 +106,9 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
         }
         else if (underlyingValueType == typeof(long) || underlyingValueType == typeof(ulong))
         {
-            if (underlyingValue is ulong)
+            if (underlyingValue is ulong underlyingValueAsULong)
             {
-                underlyingValue = Convert.ChangeType(underlyingValue, typeof(long))!;
+                underlyingValue = (long)underlyingValueAsULong;
             }
 
             bsonWriter.WriteInt64((long)underlyingValue);
@@ -180,7 +180,7 @@ public class ConceptSerializer<T> : IBsonSerializer<T>
             var value = bsonReader.ReadInt64();
             if (valueType == typeof(ulong))
             {
-                return Convert.ChangeType(value, typeof(ulong))!;
+                return (ulong)value;
             }
             return value;
         }


### PR DESCRIPTION
### Fixed

- Fixed `ConceptAs` serializer for values of `ulong` (`UInt64`) types. Instead of calling `Converter.ChangeType()` which actually throws an exception if the value is outside the range of what is `MinValue` or `MaxValue` of a `long` (`Int64`), we now cast it using a regular cast from `ulong` to `long` and back to `ulong` when deserializing from Bson.
