### PR TITLE
Fix/discriminators

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (Samples - not just my code)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build sample",
+            "program": "${workspaceFolder}/Samples/bin/Debug/net6.0/Samples.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/Samples",
+            "stopAtEntry": false,
+            "justMyCode": false,
+            "requireExactSource": false,
+            "symbolOptions": {
+                "moduleFilter": {
+                    "mode": "loadOnlyIncluded",
+                    "includedModules": [
+                        "mongodb.*.dll"
+                    ]
+                },
+                "searchPaths": [],
+                "searchMicrosoftSymbolServer": false,
+                "searchNuGetOrgSymbolServer": true
+            },
+            "suppressJITOptimizations": true,
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {}
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ],
+    "compounds": []
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build sample",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "--no-restore",
+                "${workspaceFolder}/Samples/Samples.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/MongoDB.sln
+++ b/MongoDB.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB", "Source\MongoDB.c
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MongoDB.Specs", "Specifications\MongoDB.csproj", "{F9309A45-62CE-4535-AECC-3CF79CBB2F40}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples", "Samples\Samples.csproj", "{25DF84A1-16BF-43CF-947B-11D407FC28D3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{F9309A45-62CE-4535-AECC-3CF79CBB2F40}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9309A45-62CE-4535-AECC-3CF79CBB2F40}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9309A45-62CE-4535-AECC-3CF79CBB2F40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25DF84A1-16BF-43CF-947B-11D407FC28D3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25DF84A1-16BF-43CF-947B-11D407FC28D3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25DF84A1-16BF-43CF-947B-11D407FC28D3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25DF84A1-16BF-43CF-947B-11D407FC28D3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Samples/Bar.cs
+++ b/Samples/Bar.cs
@@ -1,0 +1,3 @@
+namespace Samples;
+
+public record Bar(string Something);

--- a/Samples/Blah.cs
+++ b/Samples/Blah.cs
@@ -1,0 +1,4 @@
+namespace Samples;
+
+public record Blah(string Name, int Age, object Foo);
+

--- a/Samples/Foo.cs
+++ b/Samples/Foo.cs
@@ -1,0 +1,3 @@
+namespace Samples;
+
+public record Foo(string Cat, string Horse, object Bar);

--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -1,0 +1,38 @@
+﻿using Aksio.MongoDB;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Driver;
+using Samples;
+
+MongoDBDefaults.Initialize();
+
+BsonClassMap.RegisterClassMap<Blah>(cm =>
+{
+    cm.AutoMap();
+    cm.MapField(_ => _.Foo).SetSerializer(BsonSerializer.LookupSerializer<object>());
+    // cm.SetDiscriminator("Blah");
+    // cm.MapField("_bar").SetElementName("bar");
+});
+
+// BsonClassMap.RegisterClassMap<Bar>(cm =>
+// {
+//     cm.AutoMap();
+//     cm.SetDiscriminator(typeof(Bar).AssemblyQualifiedName);
+// });
+
+var client = new MongoClient("mongodb://localhost:27017");
+var db = client.GetDatabase("test");
+db.DropCollection("blahs");
+var collection = db.GetCollection<Blah>();
+
+var b = new Blah("Hello", 42, new Bar("aasd"));
+var doc = b.ToBsonDocument();
+
+// collection.InsertOne(new Blah("Hello", 42, "Something"));
+collection.InsertOne(new Blah("Hello", 42, new Bar("aasd")));
+collection.InsertOne(new Blah("Hello", 42, new Foo("Cat", "Horse", "Bar")));
+collection.InsertOne(new Blah("Hello", 42, new Foo("Cat", "Horse", new Bar("Something"))));
+
+
+// var items = collection.Find(_ => true).ToList();
+collection.Find(_ => true).ToList().ForEach(Console.WriteLine);

--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Source\MongoDB.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Source/ConventionPacks.cs
+++ b/Source/ConventionPacks.cs
@@ -17,4 +17,9 @@ public static class ConventionPacks
     /// Gets the ignore extra elements convention pack name.
     /// </summary>
     public const string IgnoreExtraElements = "Ignore extra elements convention";
+
+    /// <summary>
+    /// Gets the custom object discriminator convention pack name.
+    /// </summary>
+    public const string CustomObjectDiscriminator = "Custom object discriminator convention";
 }

--- a/Source/CustomDiscriminatorConvention.cs
+++ b/Source/CustomDiscriminatorConvention.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Aksio.MongoDB;
+
+/// <summary>
+/// Represents a custom convention for setting the default discriminator on class maps.
+/// </summary>
+public class CustomDiscriminatorConvention : ConventionBase, IClassMapConvention
+{
+    readonly IDiscriminatorConvention _convention;
+    readonly IEnumerable<Type> _typesWithDiscriminatorConvention;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomDiscriminatorConvention"/> class.
+    /// </summary>
+    /// <param name="convention"><see cref="IDiscriminatorConvention"/> to use.</param>
+    /// <param name="typesWithDiscriminatorConvention">Collection of <see cref="Type"/> that already has a discriminator convention. </param>
+    public CustomDiscriminatorConvention(IDiscriminatorConvention convention, IEnumerable<Type> typesWithDiscriminatorConvention)
+    {
+        _convention = convention;
+        _typesWithDiscriminatorConvention = typesWithDiscriminatorConvention;
+    }
+
+    /// <inheritdoc/>
+    public void Apply(BsonClassMap classMap)
+    {
+        var type = classMap.ClassType;
+
+        if (!_typesWithDiscriminatorConvention.Contains(type) &&
+            type.IsClass
+            && type != typeof(string)
+            && type != typeof(object)
+            && !type.IsAbstract)
+        {
+            classMap.SetDiscriminator(_convention.GetDiscriminator(type, type).ToString());
+        }
+    }
+}

--- a/Source/CustomObjectDiscriminatorConvention.cs
+++ b/Source/CustomObjectDiscriminatorConvention.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Aksio.MongoDB;
+
+/// <summary>
+/// Represents a custom <see cref="IDiscriminatorConvention"/> for handling object properties.
+/// </summary>
+public class CustomObjectDiscriminatorConvention : IDiscriminatorConvention
+{
+    internal static readonly CustomObjectDiscriminatorConvention Instance = new();
+    readonly ObjectDiscriminatorConvention _convention;
+
+    /// <inheritdoc/>
+    public string ElementName => _convention.ElementName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomObjectDiscriminatorConvention"/> class.
+    /// </summary>
+    public CustomObjectDiscriminatorConvention()
+    {
+        _convention = new("_t");
+    }
+
+    /// <inheritdoc/>
+    public Type GetActualType(IBsonReader bsonReader, Type nominalType)
+    {
+        Type? actualType = null;
+        var bookmark = bsonReader.GetBookmark();
+        bsonReader.ReadStartDocument();
+        if (bsonReader.FindElement(_convention.ElementName))
+        {
+            var context = BsonDeserializationContext.CreateRoot(bsonReader);
+            var discriminator = BsonValueSerializer.Instance.Deserialize(context);
+            if (discriminator is BsonString discriminatorString)
+            {
+                actualType = Type.GetType(discriminatorString.Value);
+            }
+        }
+
+        bsonReader.ReturnToBookmark(bookmark);
+        return actualType ?? _convention.GetActualType(bsonReader, nominalType);
+    }
+
+    /// <inheritdoc/>
+    public BsonValue GetDiscriminator(Type nominalType, Type actualType)
+    {
+        return actualType.AssemblyQualifiedName;
+    }
+}

--- a/Source/MongoDBDefaults.cs
+++ b/Source/MongoDBDefaults.cs
@@ -68,7 +68,7 @@ public static class MongoDBDefaults
             // By adding an object serializer for object configured explicitly with the Standard representation it should get serialized correctly and not throw an exception.
             // As described here: https://jira.mongodb.org/browse/CSHARP-3780
             BsonSerializer
-                .RegisterSerializer(new ObjectSerializer(BsonSerializer.LookupDiscriminatorConvention(typeof(object)), GuidRepresentation.Standard));
+                .RegisterSerializer(new ObjectSerializer(CustomObjectDiscriminatorConvention.Instance, GuidRepresentation.Standard, t => true));
 
             foreach (var derivedType in derivedTypes.TypesWithDerivatives)
             {
@@ -79,6 +79,7 @@ public static class MongoDBDefaults
 
             RegisterConventionAsPack(conventionPackFilters, ConventionPacks.CamelCase, new CamelCaseElementNameConvention());
             RegisterConventionAsPack(conventionPackFilters, ConventionPacks.IgnoreExtraElements, new IgnoreExtraElementsConvention(true));
+            RegisterConventionAsPack(conventionPackFilters, ConventionPacks.CustomObjectDiscriminator, new CustomDiscriminatorConvention(CustomObjectDiscriminatorConvention.Instance, derivedTypes.TypesWithDerivatives));
 
             RegisterClassMaps(mongoDBArtifacts);
         }


### PR DESCRIPTION
### Added

- Added a custom discriminator convention and a class map convention that overrides all types and sets the default discriminator to the `AssemblyQualifiedName`, allowing it to actually find the correct type when deserializing, which was not the case at all for our things.

### Fixed

- Allowing all types to be serialized with a discriminator, fixing a behavioral breaking change in the MongoDB driver.
