### PR TITLE
Going for fullname instead of assembly qualified name

### DIFF
--- a/Source/CustomObjectDiscriminatorConvention.cs
+++ b/Source/CustomObjectDiscriminatorConvention.cs
@@ -51,6 +51,6 @@ public class CustomObjectDiscriminatorConvention : IDiscriminatorConvention
     /// <inheritdoc/>
     public BsonValue GetDiscriminator(Type nominalType, Type actualType)
     {
-        return actualType.AssemblyQualifiedName;
+        return actualType.FullName;
     }
 }


### PR DESCRIPTION
** IMPORTANT **
This version is a breaking change from the previous. Due to minutes between release, we're going for "its probably fine" :) 

### Fixed

- Switched from `AssemblyQualifiedName` to `FullName`.

