### PR TITLE
Adding assemblyname to the discriminator for types

### DIFF
--- a/Source/CustomObjectDiscriminatorConvention.cs
+++ b/Source/CustomObjectDiscriminatorConvention.cs
@@ -49,8 +49,6 @@ public class CustomObjectDiscriminatorConvention : IDiscriminatorConvention
     }
 
     /// <inheritdoc/>
-    public BsonValue GetDiscriminator(Type nominalType, Type actualType)
-    {
-        return actualType.FullName;
-    }
+    public BsonValue GetDiscriminator(Type nominalType, Type actualType) =>
+        $"{actualType.FullName}, {actualType.Assembly.GetName().Name}";
 }


### PR DESCRIPTION
### Fixed

- Adding the short assembly name to the discriminators for types, the format is then `{Type.Fullname}, {Assembly.Name}`. We don't want version info, just enough to get back to types.
