### PR TITLE
Create an ElementNameConvention that uses the ToCamelCase method from…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,21 +1,20 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="Aksio.Defaults" Version="1.6.10" />
-		<PackageVersion Include="Aksio.Defaults.Specs" Version="1.6.10" />
-		<PackageVersion Include="Aksio.Fundamentals" Version="1.6.0" />
-        <PackageVersion Include="MongoDB.Driver" Version="2.22.0" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-        <PackageVersion Include="castle.core" Version="5.1.1" />
-        <PackageVersion Include="polly.core" Version="8.2.0" />
-
-        <!-- Specifications -->
-		<PackageVersion Include="Aksio.Specifications" Version="2.0.1" />
-		<PackageVersion Include="xunit" Version="2.4.2" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
-		<PackageVersion Include="moq" Version="4.18.4" />
-		<PackageVersion Include="Microsoft.NET.Test.SDK" Version="16.10.0" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Aksio.Defaults" Version="1.6.10" />
+    <PackageVersion Include="Aksio.Defaults.Specs" Version="1.6.10" />
+    <PackageVersion Include="Aksio.Fundamentals" Version="1.6.1" />
+    <PackageVersion Include="MongoDB.Driver" Version="2.22.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="castle.core" Version="5.1.1" />
+    <PackageVersion Include="polly.core" Version="8.2.0" />
+    <!-- Specifications -->
+    <PackageVersion Include="Aksio.Specifications" Version="2.0.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.2" />
+    <PackageVersion Include="moq" Version="4.18.4" />
+    <PackageVersion Include="Microsoft.NET.Test.SDK" Version="16.10.0" />
+  </ItemGroup>
 </Project>

--- a/Source/AcronymFriendlyCamelCaseElementNameConvention.cs
+++ b/Source/AcronymFriendlyCamelCaseElementNameConvention.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Aksio Insurtech. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Aksio.Strings;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+
+namespace Aksio.MongoDB;
+
+/// <summary>
+/// <para>A convention that sets the element name the same as the member name with the first character lower cased unless it starts with an acronym.</para>
+/// <para>Based on https://github.com/mongodb/mongo-csharp-driver/blob/f41c21efa6061f92c955748caaca123dae8e51ac/src/MongoDB.Bson/Serialization/Conventions/CamelCaseElementNameConvention.cs.</para>
+/// </summary>
+public class AcronymFriendlyCamelCaseElementNameConvention : ConventionBase, IMemberMapConvention
+{
+    /// <summary>
+    /// Gets the name of the convention.
+    /// </summary>
+    public const string ConventionName = "Acronym-friendly camel case element name convention";
+
+    /// <summary>
+    /// Applies a modification to the member map, using the ToCamelCase method on the element name.
+    /// </summary>
+    /// <param name="memberMap">The member map.</param>
+    public void Apply(BsonMemberMap memberMap)
+    {
+        var name = memberMap.MemberName;
+        name = GetElementName(name);
+        memberMap.SetElementName(name);
+    }
+
+    string GetElementName(string memberName) => memberName.ToCamelCase();
+}

--- a/Source/MongoDBDefaults.cs
+++ b/Source/MongoDBDefaults.cs
@@ -79,7 +79,7 @@ public static class MongoDBDefaults
             BsonSerializer
                 .RegisterSerializationProvider(new DerivedTypeSerializerProvider(derivedTypes, jsonSerializerOptions));
 
-            RegisterConventionAsPack(conventionPackFilters, ConventionPacks.CamelCase, new CamelCaseElementNameConvention());
+            RegisterConventionAsPack(conventionPackFilters, AcronymFriendlyCamelCaseElementNameConvention.ConventionName, new AcronymFriendlyCamelCaseElementNameConvention());
             RegisterConventionAsPack(conventionPackFilters, ConventionPacks.IgnoreExtraElements, new IgnoreExtraElementsConvention(true));
             RegisterConventionAsPack(conventionPackFilters, ConventionPacks.CustomObjectDiscriminator, new CustomDiscriminatorConvention(CustomObjectDiscriminatorConvention.Instance, derivedTypes.TypesWithDerivatives));
 


### PR DESCRIPTION
## Summary

Create an ElementNameConvention that uses the ToCamelCase method from fundamentals and set this in the MongoDBDefaults.

We need consistency of json name handling across Mongo, System.Text.Json, etc.

