### PR TITLE
Switching to using async/await internally to interceptor to guarantee correct synchronoization context

### DIFF
--- a/Samples/Program.cs
+++ b/Samples/Program.cs
@@ -1,10 +1,13 @@
 ﻿using Aksio.MongoDB;
+using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using Samples;
 
 MongoDBDefaults.Initialize();
+var loggerFactory = new LoggerFactory();
+var factory = new MongoDBClientFactory(loggerFactory.CreateLogger<MongoDBClientFactory>());
 
 BsonClassMap.RegisterClassMap<Blah>(cm =>
 {
@@ -20,7 +23,7 @@ BsonClassMap.RegisterClassMap<Blah>(cm =>
 //     cm.SetDiscriminator(typeof(Bar).AssemblyQualifiedName);
 // });
 
-var client = new MongoClient("mongodb://localhost:27017");
+var client = factory.Create("mongodb://localhost:27017");
 var db = client.GetDatabase("test");
 db.DropCollection("blahs");
 var collection = db.GetCollection<Blah>();
@@ -29,10 +32,9 @@ var b = new Blah("Hello", 42, new Bar("aasd", typeof(string)));
 var doc = b.ToBsonDocument();
 
 // collection.InsertOne(new Blah("Hello", 42, "Something"));
-collection.InsertOne(new Blah("Hello", 42, new Bar("aasd", typeof(string))));
-collection.InsertOne(new Blah("Hello", 42, new Foo("Cat", "Horse", "Bar")));
-collection.InsertOne(new Blah("Hello", 42, new Foo("Cat", "Horse", new Bar("Something", typeof(string)))));
+await collection.InsertOneAsync(new Blah("Hello", 42, new Bar("aasd", typeof(string))));
+await collection.InsertOneAsync(new Blah("Hello", 42, new Foo("Cat", "Horse", "Bar")));
+await collection.InsertOneAsync(new Blah("Hello", 42, new Foo("Cat", "Horse", new Bar("Something", typeof(string)))));
 
-
-// var items = collection.Find(_ => true).ToList();
-collection.Find(_ => true).ToList().ForEach(Console.WriteLine);
+var query = await collection.FindAsync(_ => true);
+query.ToList().ForEach(Console.WriteLine);

--- a/Specifications/Resilience/for_MongoCollectionInterceptor/when_intercepting/cancelled_method.cs
+++ b/Specifications/Resilience/for_MongoCollectionInterceptor/when_intercepting/cancelled_method.cs
@@ -6,9 +6,15 @@ namespace Aksio.MongoDB.Resilience.for_MongoCollectionInterceptor.when_intercept
 public class cancelled_method : given.an_interceptor
 {
     protected override string GetInvocationTargetMethod() => nameof(InvocationTarget.CancelledMethod);
+    Exception exception;
 
-    void Because() => interceptor.Intercept(invocation.Object);
+    async Task Because()
+    {
+        interceptor.Intercept(invocation.Object);
+        exception = await Catch.Exception(async () => await return_value);
+    }
 
+    [Fact] void should_bubble_up_cancelled_exception() => exception.ShouldBeOfExactType<TaskCanceledException>();
     [Fact] void should_have_cancelled_task() => return_value.IsCanceled.ShouldBeTrue();
     [Fact] void should_have_freed_up_semaphore() => semaphore.CurrentCount.ShouldEqual(pool_size);
 }

--- a/Specifications/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method.cs
+++ b/Specifications/Resilience/for_MongoCollectionInterceptor/when_intercepting/faulted_method.cs
@@ -14,8 +14,7 @@ public class faulted_method : given.an_interceptor
     async Task Because()
     {
         interceptor.Intercept(invocation.Object);
-        var exceptions = (AggregateException)await Catch.Exception(async () => await return_value);
-        exception = exceptions.InnerExceptions.Single();
+        exception = await Catch.Exception(async () => await return_value);
     }
 
     [Fact] void should_be_faulted() => return_value.IsFaulted.ShouldBeTrue();

--- a/Specifications/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/cancelled_method.cs
+++ b/Specifications/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/cancelled_method.cs
@@ -6,9 +6,15 @@ namespace Aksio.MongoDB.Resilience.for_MongoCollectionInterceptorForReturnValue.
 public class cancelled_method : given.an_interceptor
 {
     protected override string GetInvocationTargetMethod() => nameof(InvocationTarget.CancelledMethod);
+    Exception exception;
 
-    void Because() => interceptor.Intercept(invocation.Object);
+    async Task Because()
+    {
+        interceptor.Intercept(invocation.Object);
+        exception = await Catch.Exception(async () => await return_value);
+    }
 
+    [Fact] void should_bubble_up_cancelled_exception() => exception.ShouldBeOfExactType<TaskCanceledException>();
     [Fact] void should_have_cancelled_task() => return_value.IsCanceled.ShouldBeTrue();
     [Fact] void should_have_freed_up_semaphore() => semaphore.CurrentCount.ShouldEqual(pool_size);
 }

--- a/Specifications/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method.cs
+++ b/Specifications/Resilience/for_MongoCollectionInterceptorForReturnValue/when_intercepting/faulted_method.cs
@@ -14,8 +14,7 @@ public class faulted_method : given.an_interceptor
     async Task Because()
     {
         interceptor.Intercept(invocation.Object);
-        var exceptions = (AggregateException)await Catch.Exception(async () => await return_value);
-        exception = exceptions.InnerExceptions.Single();
+        exception = await Catch.Exception(async () => await return_value);
     }
 
     [Fact] void should_be_faulted() => return_value.IsFaulted.ShouldBeTrue();


### PR DESCRIPTION
### Fixed

- Fixing collection interceptors to guarantee correct synchronization context by using `async`/`await` internally to them.
